### PR TITLE
added call to save datastore when outfits are saved.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -20,6 +20,7 @@ AddEventHandler('esx_clotheshop:saveOutfit', function(label, skin)
 		})
 
 		store.set('dressing', dressing)
+		store.save()
 	end)
 end)
 


### PR DESCRIPTION
noticed outfits saved to the local server copy of the db but all changes are lost upon restart. Added a call to the esx_datastore save function to save commit changes to datastore each time an outfit is saved.